### PR TITLE
Problem: Mutable borrow prevents multiple futures from queing requests

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -13,7 +13,7 @@ use tokio_core::reactor::Core;
 pub fn main() -> Result<(), Error> {
     let mut core = Core::new().unwrap();
     let client = Client::new();
-    let mut capped = ch::Client::new(client, 2);
+    let capped = ch::Client::new(client, 2);
 
     let uris = vec![
         "http://worldclockapi.com/api/json/utc/now",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ impl<C: Connect + 'static> Client<C> {
         }
     }
 
-    pub fn request(&mut self, req: Request<Body>) -> CappedFuture {
+    pub fn request(&self, req: Request<Body>) -> CappedFuture {
         let inner = self.client.request(req);
 
         CappedFuture {


### PR DESCRIPTION
Solution: Interior mutability was already implemented on
`capped::Client`, so simply expose that in the public interface.

This is needed in the scraper I'm working on. It enables, for example, futures that are dealing with individual pages of a paginated list to queue up requests for subsequent pages.